### PR TITLE
Correctly display the camera automatically moving to next cine

### DIFF
--- a/ADPhantomApp/Db/phantomCamera.template
+++ b/ADPhantomApp/Db/phantomCamera.template
@@ -84,6 +84,30 @@ record(longin, "$(P)$(R)TotalFrameCount_RBV")
 
 ################################################################
 ###
+### Automatically move to next available cine after capturing
+###
+
+record(bo, "$(P)$(R)AutoAdvance")
+{
+   field(DTYP, "asynInt32")
+   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_AUTO_ADVANCE")
+   field(ZNAM, "Off")
+   field(ONAM, "On")
+   field(VAL, "1")
+   field(PINI, "YES")
+}
+
+record(bi, "$(P)$(R)AutoAdvance_RBV")
+{
+   field(DTYP, "asynInt32")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_AUTO_ADVANCE")
+   field(ZNAM, "Off")
+   field(ONAM, "On")
+   field(SCAN, "I/O Intr")
+}
+
+################################################################
+###
 ### Auto Saving cine
 ###
 

--- a/ADPhantomApp/opi/edl/phantomDetails.edl
+++ b/ADPhantomApp/opi/edl/phantomDetails.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 229
-y 260
+x 1461
+y 331
 w 1060
 h 314
 font "arial-bold-r-12.0"
@@ -1507,5 +1507,123 @@ numDsps 1
 displayFileName {
   0 "phantomCine"
 }
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 380
+y 185
+w 94
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Auto-save Cines"
+}
+autoSize
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 490
+y 180
+w 95
+h 20
+fgColor index 25
+bgColor index 3
+inconsistentColor index 0
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)AutoSave"
+indicatorPv "$(P)$(R)AutoSave_RBV"
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 590
+y 180
+w 85
+h 20
+controlPv "$(P)$(R)AutoSave_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 380
+y 210
+w 97
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Auto-restart acq."
+}
+autoSize
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 490
+y 205
+w 95
+h 20
+fgColor index 25
+bgColor index 3
+inconsistentColor index 0
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)AutoRestart"
+indicatorPv "$(P)$(R)AutoRestart_RBV"
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 590
+y 205
+w 85
+h 20
+controlPv "$(P)$(R)AutoRestart_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomTop.edl
+++ b/ADPhantomApp/opi/edl/phantomTop.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1509
-y 437
+x 1005
+y 179
 w 400
 h 830
 font "arial-bold-r-12.0"
@@ -674,8 +674,8 @@ bgColor index 3
 inconsistentColor index 0
 topShadowColor index 1
 botShadowColor index 11
-controlPv "$(P)$(R)AutoSave"
-indicatorPv "$(P)$(R)AutoSave_RBV"
+controlPv "$(P)$(R)AutoAdvance"
+indicatorPv "$(P)$(R)AutoAdvance_RBV"
 font "arial-bold-r-12.0"
 endObjectProperties
 
@@ -689,7 +689,7 @@ x 265
 y 710
 w 85
 h 20
-controlPv "$(P)$(R)AutoSave_RBV"
+controlPv "$(P)$(R)AutoAdvance_RBV"
 fgColor index 16
 fgAlarm
 bgColor index 10
@@ -706,116 +706,16 @@ minor 1
 release 1
 x 20
 y 715
-w 120
+w 110
 h 13
 font "arial-bold-r-12.0"
 fgColor index 14
 bgColor index 3
 useDisplayBg
 value {
-  "Auto-save Cine Files"
+  "Auto-advance Cine"
 }
 autoSize
-endObjectProperties
-
-# (Menu Button)
-object activeMenuButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 175
-y 735
-w 75
-h 20
-fgColor index 25
-bgColor index 3
-inconsistentColor index 0
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(P)$(R)AutoRestart"
-indicatorPv "$(P)$(R)AutoRestart_RBV"
-font "arial-bold-r-12.0"
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 265
-y 735
-w 85
-h 20
-controlPv "$(P)$(R)AutoRestart_RBV"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-12.0"
-fontAlign "center"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 20
-y 740
-w 139
-h 13
-font "arial-bold-r-12.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "Auto-restart Acquisition"
-}
-autoSize
-endObjectProperties
-
-# (Group)
-object activeGroupClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 175
-y 790
-w 195
-h 25
-
-beginGroup
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 175
-y 790
-w 195
-h 25
-font "arial-bold-r-12.0"
-fontAlign "center"
-fgColor index 20
-bgColor index 3
-value {
-  "Cine save to flash in progress."
-}
-border
-endObjectProperties
-
-endGroup
-
-visPv "$(P)$(R)CFProgress_RBV"
-visInvert
-visMin "0"
-visMax "1"
 endObjectProperties
 
 # (Static Text)
@@ -845,7 +745,7 @@ major 4
 minor 0
 release 0
 x 175
-y 760
+y 735
 w 75
 h 20
 fgColor index 25
@@ -865,7 +765,7 @@ major 10
 minor 0
 release 0
 x 265
-y 760
+y 735
 w 85
 h 20
 controlPv "$(P)$(R)AutoBref_RBV"
@@ -884,7 +784,7 @@ major 4
 minor 1
 release 1
 x 20
-y 765
+y 740
 w 122
 h 13
 font "arial-bold-r-12.0"

--- a/ADPhantomApp/src/ADPhantom.cpp
+++ b/ADPhantomApp/src/ADPhantom.cpp
@@ -1003,6 +1003,7 @@ ADPhantom::ADPhantom(const char *portName, const char *ctrlPort, const char *dat
   createParam(PHANTOM_SettingsSlotString,             asynParamInt32,         &PHANTOM_SettingsSlot_);
   createParam(PHANTOM_SettingsSaveString,             asynParamInt32,         &PHANTOM_SettingsSave_);
   createParam(PHANTOM_SettingsLoadString,             asynParamInt32,         &PHANTOM_SettingsLoad_);
+  createParam(PHANTOM_AutoAdvanceString,              asynParamInt32,         &PHANTOM_AutoAdvance_);
   createParam(PHANTOM_AutoSaveString,                 asynParamInt32,         &PHANTOM_AutoSave_);
   createParam(PHANTOM_AutoRestartString,              asynParamInt32,         &PHANTOM_AutoRestart_);
   createParam(PHANTOM_AutoCSRString,                  asynParamInt32,         &PHANTOM_AutoCSR_);
@@ -1303,8 +1304,7 @@ void ADPhantom::phantomCameraTask()
   int lastFrame = 0;
   int frameCount = 0;
   int cineState = 0;
-  int autoSave = 0;
-  int autoAcquire = 0;
+  int autoAdvance = 0;
   char command[PHANTOM_MAX_STRING];
   std::string response;
   std::string cineStr;
@@ -1393,20 +1393,17 @@ void ADPhantom::phantomCameraTask()
     setIntegerParam(ADNumImagesCounter, numImagesCounter);
     setIntegerParam(PHANTOM_TotalFrameCount_, frameCount);
 
-    getIntegerParam(PHANTOM_AutoSave_, &autoSave);
-    getIntegerParam(PHANTOM_AutoRestart_, &autoAcquire);
+    getIntegerParam(PHANTOM_AutoAdvance_, &autoAdvance);
 
     debug(functionName, "cineState", cineState);
     debug(functionName, "cineState", (cineState & PHANTOM_CINE_STATE_STR));
     if ((cineState & PHANTOM_CINE_STATE_STR) == PHANTOM_CINE_STATE_STR){
       bool found = false;
-      // Check if set to auto record cines
-      if (autoSave == 1 && autoAcquire == 1){
+      // Check if set to auto advance to next available cine
+      if (autoAdvance){
         // Find the next active cine
-        for( int index{1}; index < PHANTOM_NUMBER_OF_CINES; index++){
-          updateCine(index);
-        }
         for (int index = 1; index < PHANTOM_NUMBER_OF_CINES; index++){
+          updateCine(index);
           getIntegerParam(PHANTOM_CnStatus_[index], &cineState);
           if ((cineState & PHANTOM_CINE_STATE_ACT) == PHANTOM_CINE_STATE_ACT){
             cine = index;
@@ -1416,8 +1413,13 @@ void ADPhantom::phantomCameraTask()
             sprintf(command, "c%d", cine);
             cineStr.assign(command);
             found = true;
+            break;
           }
         }
+      }
+      else{ //Auto advance not set so stop acquisition
+        std::string response = "";
+        sendSimpleCommand(PHANTOM_CMD_ABORT, &response);
       }
       if (!found){
         acquire = 0;

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -135,6 +135,8 @@
 #define PHANTOM_SettingsSaveString             "PHANTOM_SETTINGS_SAVE"
 #define PHANTOM_SettingsLoadString             "PHANTOM_SETTINGS_LOAD"
 
+#define PHANTOM_AutoAdvanceString             "PHANTOM_AUTO_ADVANCE"
+
 #define PHANTOM_AutoSaveString                 "PHANTOM_AUTO_SAVE"
 #define PHANTOM_AutoRestartString              "PHANTOM_AUTO_RESTART"
 #define PHANTOM_AutoCSRString                  "PHANTOM_AUTO_CSR"
@@ -665,6 +667,7 @@ class ADPhantom: public ADDriver
     int PHANTOM_SettingsSlot_;
     int PHANTOM_SettingsSave_;
     int PHANTOM_SettingsLoad_;
+    int PHANTOM_AutoAdvance_;
     int PHANTOM_AutoSave_;
     int PHANTOM_AutoRestart_;
     int PHANTOM_AutoCSR_;


### PR DESCRIPTION
This changes the behaviour of the driver to correctly display the fact that after triggering it will automatically move to the next empty cine and begin capturing awaiting a trigger. An option is also added to prevent this behaviour such that after capturing a cine the camera stops acquiring.