### PR TITLE
Implementation of download abort

### DIFF
--- a/ADPhantomApp/Db/phantomCamera.template
+++ b/ADPhantomApp/Db/phantomCamera.template
@@ -321,6 +321,15 @@ record(longout, "$(P)$(R)Download")
   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DOWNLOAD")
 }
 
+### Cine abort download command
+
+record(longout, "$(P)$(R)AbortDownload")
+{
+  field(DESC, "Abort the download")
+  field(DTYP, "asynInt32")
+  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DOWNLOAD_ABORT")
+}
+
 ### Cine save to flash command
 
 record(longout, "$(P)$(R)SaveToCF")

--- a/ADPhantomApp/Db/phantomCamera.template
+++ b/ADPhantomApp/Db/phantomCamera.template
@@ -336,6 +336,28 @@ record(bi, "$(P)$(R)DownloadFrameMode_RBV")
   field(SCAN, "I/O Intr")
 }
 
+### Cine save mode 
+# Determines whether cines downloaded from are marked as saved/reusable
+
+record(bo, "$(P)$(R)MarkCineSaved")
+{
+  field(DTYP, "asynInt32")
+  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_MARK_CINE_SAVED")
+  field(ZNAM, "No")
+  field(ONAM, "Yes")
+  field(VAL, "1")
+  field(PINI, "YES")
+}
+
+record(bi, "$(P)$(R)MarkCineSaved_RBV")
+{
+  field(DTYP, "asynInt32")
+  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_MARK_CINE_SAVED")
+  field(ZNAM, "No")
+  field(ONAM, "Yes")
+  field(SCAN, "I/O Intr")
+}
+
 ### Cine download command
 
 record(longout, "$(P)$(R)Download")
@@ -352,6 +374,48 @@ record(longout, "$(P)$(R)AbortDownload")
   field(DESC, "Abort the download")
   field(DTYP, "asynInt32")
   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DOWNLOAD_ABORT")
+}
+
+### Delete start cine
+
+record(longout, "$(P)$(R)DeleteStartCine")
+{
+  field(DESC, "Delete starting cine")
+  field(DTYP, "asynInt32")
+  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DELETE_START_CINE")
+  field(VAL, "1")
+  field(PINI, "YES")
+  field(DRVL, "1")
+  field(DRVH, "63")
+}
+
+record(longin, "$(P)$(R)DeleteStartCine_RBV")
+{
+  field(DESC, "Delete starting cine")
+  field(DTYP, "asynInt32")
+  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DELETE_START_CINE")
+  field(SCAN, "I/O Intr")
+}
+
+### Delete end cine
+
+record(longout, "$(P)$(R)DeleteEndCine")
+{
+  field(DESC, "Delete ending cine")
+  field(DTYP, "asynInt32")
+  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DELETE_END_CINE")
+  field(VAL, "1")
+  field(PINI, "YES")
+  field(DRVL, "1")
+  field(DRVH, "63")
+}
+
+record(longin, "$(P)$(R)DeleteEndCine_RBV")
+{
+  field(DESC, "Delete ending cine")
+  field(DTYP, "asynInt32")
+  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DELETE_END_CINE")
+  field(SCAN, "I/O Intr")
 }
 
 ### Cine save to flash command
@@ -378,6 +442,15 @@ record(longin, "$(P)$(R)StateRaw") {
 
 record(mbbiDirect, "$(P)$(R)State_RBV") {
   field(INP, "$(P)$(R)StateRaw")
+}
+
+### Cine delete command
+
+record(longout, "$(P)$(R)Delete")
+{
+  field(DESC, "Delete Cines")
+  field(DTYP, "asynInt32")
+  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DELETE")
 }
 
 ################################################################

--- a/ADPhantomApp/opi/edl/phantomCine.edl
+++ b/ADPhantomApp/opi/edl/phantomCine.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 165
-y 165
+x 688
+y 260
 w 1085
 h 670
 font "arial-bold-r-12.0"
@@ -8894,6 +8894,29 @@ numPvs 4
 numDsps 1
 displayFileName {
   0 "phantomDownload"
+}
+endObjectProperties
+
+# (Related Display)
+object relatedDisplayClass
+beginObjectProperties
+major 4
+minor 4
+release 0
+x 845
+y 605
+w 105
+h 25
+fgColor index 14
+bgColor index 3
+topShadowColor index 1
+botShadowColor index 11
+font "arial-bold-r-12.0"
+buttonLabel "Delete"
+numPvs 4
+numDsps 1
+displayFileName {
+  0 "phantomDelete"
 }
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomCineDetails.edl
+++ b/ADPhantomApp/opi/edl/phantomCineDetails.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 971
-y 571
+x 1595
+y 274
 w 401
 h 321
 font "arial-bold-r-12.0"
@@ -1036,6 +1036,50 @@ endObjectProperties
 endGroup
 
 visPv "$(P)$(R)DownloadCount_RBV"
+visMin "0"
+visMax "1"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 280
+w 85
+h 30
+
+beginGroup
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 180
+y 280
+w 85
+h 30
+fgColor index 20
+onColor index 3
+offColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)AbortDownload"
+pressValue "1"
+onLabel "Abort"
+offLabel "Abort"
+3d
+font "arial-bold-r-12.0"
+endObjectProperties
+
+endGroup
+
+visPv "$(P)$(R)DownloadCount_RBV"
+visInvert
 visMin "0"
 visMax "1"
 endObjectProperties

--- a/ADPhantomApp/opi/edl/phantomDelete.edl
+++ b/ADPhantomApp/opi/edl/phantomDelete.edl
@@ -1,0 +1,312 @@
+4 0 1
+beginScreenProperties
+major 4
+minor 0
+release 1
+x 1380
+y 446
+w 400
+h 175
+font "arial-bold-r-12.0"
+fontAlign "center"
+ctlFont "arial-bold-r-12.0"
+btnFont "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+textColor index 14
+ctlFgColor1 index 25
+ctlFgColor2 index 25
+ctlBgColor1 index 3
+ctlBgColor2 index 3
+topShadowColor index 1
+botShadowColor index 11
+showGrid
+snapToGrid
+gridSize 5
+endScreenProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 0
+w 400
+h 175
+lineColor index 5
+fill
+fillColor index 5
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 15
+w 390
+h 155
+lineColor index 14
+fill
+fillColor index 3
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 5
+w 2
+h 13
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 5
+value {
+  "  Cine File C$(cine)   "
+}
+autoSize
+border
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 275
+y 130
+w 85
+h 30
+
+beginGroup
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 275
+y 130
+w 85
+h 30
+fgColor index 20
+onColor index 3
+offColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)Delete"
+pressValue "0"
+onLabel "Delete"
+offLabel "Delete"
+3d
+font "arial-bold-r-12.0"
+endObjectProperties
+
+endGroup
+
+visMin "0"
+visMax "1"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 20
+y 100
+w 37
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Cines:"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 140
+y 95
+w 50
+h 20
+controlPv "$(P)$(R)DeleteStartCine_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 90
+y 95
+w 50
+h 20
+controlPv "$(P)$(R)DeleteStartCine"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 215
+y 95
+w 50
+h 20
+controlPv "$(P)$(R)DeleteEndCine"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 265
+y 95
+w 50
+h 20
+controlPv "$(P)$(R)DeleteEndCine_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 195
+y 100
+w 15
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "to:"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 20
+y 35
+w 2
+h 14
+font "arial-medium-r-14.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Delete cine deta"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 130
+y 25
+w 126
+h 17
+font "arial-bold-r-16.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Delete cine data"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 20
+y 65
+w 40
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Status:"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 75
+y 60
+w 315
+h 20
+controlPv "$(P)$(R)StatusMessage_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+

--- a/ADPhantomApp/opi/edl/phantomDetails.edl
+++ b/ADPhantomApp/opi/edl/phantomDetails.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1461
-y 331
+x 300
+y 111
 w 1060
 h 314
 font "arial-bold-r-12.0"
@@ -1576,14 +1576,14 @@ minor 1
 release 1
 x 380
 y 210
-w 97
+w 69
 h 13
 font "arial-bold-r-12.0"
 fgColor index 14
 bgColor index 3
 useDisplayBg
 value {
-  "Auto-restart acq."
+  "Auto-restart"
 }
 autoSize
 endObjectProperties

--- a/ADPhantomApp/opi/edl/phantomDownload.edl
+++ b/ADPhantomApp/opi/edl/phantomDownload.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 794
-y 447
+x 217
+y 443
 w 401
 h 250
 font "arial-bold-r-12.0"
@@ -176,7 +176,7 @@ major 10
 minor 0
 release 0
 x 145
-y 180
+y 200
 w 85
 h 20
 controlPv "$(P)$(R)DownloadCount_RBV"
@@ -195,7 +195,7 @@ major 4
 minor 1
 release 1
 x 20
-y 185
+y 205
 w 112
 h 13
 font "arial-bold-r-12.0"
@@ -548,5 +548,45 @@ visPv "$(P)$(R)DownloadCount_RBV"
 visInvert
 visMin "0"
 visMax "1"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 20
+y 170
+w 106
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Mark cines saved:"
+}
+autoSize
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 145
+y 165
+w 110
+h 25
+fgColor index 14
+bgColor index 3
+inconsistentColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)MarkCineSaved"
+indicatorPv "$(P)$(R)MarkCineSaved_RBV"
+font "arial-bold-r-12.0"
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomDownload.edl
+++ b/ADPhantomApp/opi/edl/phantomDownload.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1215
-y 701
+x 794
+y 447
 w 401
 h 250
 font "arial-bold-r-12.0"
@@ -504,5 +504,49 @@ botShadowColor index 11
 controlPv "$(P)$(R)DownloadFrameMode"
 indicatorPv "$(P)$(R)DownloadFrameMode_RBV"
 font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 270
+y 175
+w 85
+h 30
+
+beginGroup
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 270
+y 175
+w 85
+h 30
+fgColor index 20
+onColor index 3
+offColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)AbortDownload"
+pressValue "1"
+onLabel "Abort"
+offLabel "Abort"
+3d
+font "arial-bold-r-12.0"
+endObjectProperties
+
+endGroup
+
+visPv "$(P)$(R)DownloadCount_RBV"
+visInvert
+visMin "0"
+visMax "1"
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomTop.edl
+++ b/ADPhantomApp/opi/edl/phantomTop.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1005
-y 179
+x 1597
+y 134
 w 400
 h 830
 font "arial-bold-r-12.0"
@@ -745,7 +745,7 @@ major 4
 minor 0
 release 0
 x 175
-y 735
+y 760
 w 75
 h 20
 fgColor index 25
@@ -765,7 +765,7 @@ major 10
 minor 0
 release 0
 x 265
-y 735
+y 760
 w 85
 h 20
 controlPv "$(P)$(R)AutoBref_RBV"
@@ -784,7 +784,7 @@ major 4
 minor 1
 release 1
 x 20
-y 740
+y 765
 w 122
 h 13
 font "arial-bold-r-12.0"
@@ -855,5 +855,64 @@ numDsps 1
 displayFileName {
   0 "phantomDownload"
 }
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 175
+y 735
+w 75
+h 20
+fgColor index 25
+bgColor index 3
+inconsistentColor index 0
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)AutoRestart"
+indicatorPv "$(P)$(R)AutoRestart_RBV"
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 265
+y 735
+w 85
+h 20
+controlPv "$(P)$(R)AutoRestart_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 20
+y 740
+w 69
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Auto-restart"
+}
+autoSize
 endObjectProperties
 

--- a/ADPhantomApp/src/ADPhantom.cpp
+++ b/ADPhantomApp/src/ADPhantom.cpp
@@ -2123,7 +2123,15 @@ asynStatus ADPhantom::writeInt32(asynUser *pasynUser, epicsInt32 value)
       setIntegerParam(ADStatus, ADStatusError);
       status |= asynError;
     } else {
-      status |= downloadFlashFile();
+      int downloadCount = 0;
+      getIntegerParam(PHANTOM_DownloadCount_, &downloadCount);
+      if(downloadCount){
+        setStringParam(ADStatusMessage, "Cannot download to flash while downloading to file");  
+        setIntegerParam(ADStatus, ADStatusError);
+        status |= asynError;
+      } else{
+        status |= downloadFlashFile();
+      }
     }
   } else if (function == PHANTOM_CFSFileDelete_){
     // Delete the flash file

--- a/ADPhantomApp/src/ADPhantom.cpp
+++ b/ADPhantomApp/src/ADPhantom.cpp
@@ -961,7 +961,6 @@ ADPhantom::ADPhantom(const char *portName, const char *ctrlPort, const char *dat
   // Initialise the debugger
   initDebugger(0);
 
-
   //Initialize non static data members
   portUser_  = NULL;
   dataChannel_ = NULL;
@@ -1532,9 +1531,11 @@ void ADPhantom::phantomDownloadTask()
       if (start_cine < 1 || start_cine > num_cines){
         rangeValid=false;
         setStringParam(ADStatusMessage, "start_cine value invalid");
+        debug(functionName, "start_cine value invalid");
       }  else if (end_cine < 1 || end_cine > num_cines){
         rangeValid=false;
         setStringParam(ADStatusMessage, "end_cine value invalid");
+        debug(functionName, "end_cine value invalid");
       } else if(uni_frame_lim){ //Start frame and end frame are applied to every cine
         int first_frame = 0;
         int last_frame = 0;
@@ -1547,16 +1548,19 @@ void ADPhantom::phantomDownloadTask()
             char message[256];
             sprintf(message, "start_frame value invalid in cine %d", cine);
             setStringParam(ADStatusMessage, message);
+            debug(functionName, message);
             break;
           } else if(end_frame < first_frame || end_frame > last_frame ){
             rangeValid=false;
             char message[256];
             sprintf(message, "end_frame value invalid in cine %d", cine);
             setStringParam(ADStatusMessage, message);
+            debug(functionName, message);
             break;
           } else if(end_frame < start_frame){
             rangeValid=false;
             setStringParam(ADStatusMessage, "start_frame cannot be after end_frame");
+            debug(functionName, "start_frame cannot be after end_frame");
             break;
           }
         }
@@ -1593,6 +1597,9 @@ void ADPhantom::phantomDownloadTask()
         status = readoutDataStream(start_cine, end_cine, start_frame, end_frame, uni_frame_lim);
 
         setStringParam(ADStatusMessage, "Ready");
+      }
+      else{
+        setStringParam(ADStatus, ADStatusError);
       }
    }  
   }

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -30,6 +30,7 @@
 
 // Asyn driver includes
 #include "asynOctetSyncIO.h"
+#include "asynCommonSyncIO.h"
 
 // Phantom camera PH16 protocol data definitions
 #include <ph16UnitStructure.h>
@@ -776,6 +777,7 @@ class ADPhantom: public ADDriver
 
     asynUser                           *portUser_;
     asynUser                           *dataChannel_;
+    asynUser                           *commonDataport_;
     char                               ctrlPort_[128];
     char                               dataPort_[128];
     char                               data_[2048000];

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -584,6 +584,7 @@ class ADPhantom: public ADDriver
     void phantomStatusTask();
     void phantomPreviewTask();
     void phantomFlashTask();
+    void phantomDownloadTask();
     asynStatus makeConnection();
     asynStatus connect();
     asynStatus disconnect();
@@ -792,6 +793,7 @@ class ADPhantom: public ADDriver
     std::map<std::string, int>         debugMap_;
     epicsEventId                       startEventId_;
     epicsEventId                       stopEventId_;
+    epicsEventId                       startDownloadEventId_;
     epicsEventId                       startPreviewEventId_;
     epicsEventId                       stopPreviewEventId_;
     epicsEventId                       flashEventId_;

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -155,6 +155,7 @@
 #define PHANTOM_DownloadStartCineString        "PHANTOM_DOWNLOAD_START_CINE"
 #define PHANTOM_DownloadEndCineString          "PHANTOM_DOWNLOAD_END_CINE"
 #define PHANTOM_DownloadString                 "PHANTOM_DOWNLOAD"
+#define PHANTOM_DownloadAbortString            "PHANTOM_DOWNLOAD_ABORT"
 #define PHANTOM_DownloadCountString            "PHANTOM_DOWNLOAD_COUNT"
 #define PHANTOM_DownloadFrameModeString        "PHANTOM_DOWNLOAD_FRAME_MODE"
 #define PHANTOM_CineSaveCFString               "PHANTOM_CINE_SAVE_CF"       // Save selected cine to flash
@@ -687,6 +688,7 @@ class ADPhantom: public ADDriver
     int PHANTOM_DownloadStartCine_;
     int PHANTOM_DownloadEndCine_;
     int PHANTOM_Download_;
+    int PHANTOM_DownloadAbort_;
     int PHANTOM_DownloadCount_;
     int PHANTOM_DownloadFrameMode_;
     int PHANTOM_CineSaveCF_;

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -161,7 +161,12 @@
 #define PHANTOM_DownloadAbortString            "PHANTOM_DOWNLOAD_ABORT"
 #define PHANTOM_DownloadCountString            "PHANTOM_DOWNLOAD_COUNT"
 #define PHANTOM_DownloadFrameModeString        "PHANTOM_DOWNLOAD_FRAME_MODE"
+#define PHANTOM_MarkCineSavedString            "PHANTOM_MARK_CINE_SAVED"
 #define PHANTOM_CineSaveCFString               "PHANTOM_CINE_SAVE_CF"       // Save selected cine to flash
+
+#define PHANTOM_DeleteString                   "PHANTOM_DELETE"
+#define PHANTOM_DeleteStartCineString          "PHANTOM_DELETE_START_CINE"
+#define PHANTOM_DeleteEndCineString            "PHANTOM_DELETE_END_CINE"
 
 #define PHANTOM_SetPartitionString             "PHANTOM_SET_PARTITION"
 #define PHANTOM_GetCineCountString             "PHANTOM_GET_CINE_COUNT"
@@ -601,7 +606,7 @@ class ADPhantom: public ADDriver
     asynStatus attachToPort(const std::string& portName);
     asynStatus readoutPreviewData();
     asynStatus sendSoftwareTrigger();
-    asynStatus downloadCineFile();
+    asynStatus deleteCineFiles();
     asynStatus saveCineToFlash(int cine);
     asynStatus saveSettings();
     asynStatus loadSettings();
@@ -696,7 +701,11 @@ class ADPhantom: public ADDriver
     int PHANTOM_DownloadAbort_;
     int PHANTOM_DownloadCount_;
     int PHANTOM_DownloadFrameMode_;
+    int PHANTOM_MarkCineSaved_;
     int PHANTOM_CineSaveCF_;
+    int PHANTOM_Delete_;
+    int PHANTOM_DeleteStartCine_;
+    int PHANTOM_DeleteEndCine_;
     int PHANTOM_SetPartition_;
     int PHANTOM_GetCineCount_;
     int PHANTOM_CFState_;


### PR DESCRIPTION
This moves the download process to its own thread and implements an abort command. 
All comments are naturally welcome but I'm particularly concerned with the locking and unlocking within readoutDataStream. I added an unlock after `setIntegerParam(NDArraySizeY, height);` (line 3346) and then relocked before `getIntegerParam(NDArrayCallbacks, &arrayCallbacks);`  (line 3427) my logic being that I don't think any other thread should be touching pImage. 