### PR TITLE
Implement bitdepths fix

### DIFF
--- a/ADPhantomApp/Db/phantomCamera.template
+++ b/ADPhantomApp/Db/phantomCamera.template
@@ -1184,8 +1184,8 @@ record(mbbo, "$(P)$(R)SelectPixelDataFormat")
   field(THVL, "3")
   field(FRST, "P10")
   field(FRVL, "4")
-  field(SXST, "P12L")
-  field(SXVL, "5")
+  field(FVST, "P12L")
+  field(FVVL, "5")
 }
 
 

--- a/ADPhantomApp/Db/phantomCamera.template
+++ b/ADPhantomApp/Db/phantomCamera.template
@@ -998,6 +998,27 @@ record(bi, "$(P)$(R)CONNECTED_RBV")
   field(ONAM, "Connected")
 }
 
+# Choose the format of camera pixel data
+record(mbbo, "$(P)$(R)SelectPixelDataFormat")
+{
+  field(DESC, "Phantom pixel data format token")
+  field(DTYP, "asynInt32")
+  field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_DataFormat")
+  field(ZRST, "8")
+  field(ZRVL, "0")
+  field(ONST, "8R")
+  field(ONVL, "1")
+  field(TWST, "P16")
+  field(TWVL, "2")
+  field(THST, "P16R")
+  field(THVL, "3")
+  field(FRST, "P10")
+  field(FRVL, "4")
+  field(SXST, "P12L")
+  field(SXVL, "5")
+}
+
+
 include "phantomFlash.template"
 
 

--- a/ADPhantomApp/opi/edl/phantomBase.edl
+++ b/ADPhantomApp/opi/edl/phantomBase.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 179
-y 470
+x 429
+y 343
 w 390
 h 470
 font "arial-bold-r-12.0"
@@ -40,25 +40,6 @@ useDisplayBg
 value {
   "Pixel Data Type"
 }
-endObjectProperties
-
-# (Menu Button)
-object activeMenuButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 306
-y 205
-w 74
-h 20
-fgColor index 14
-bgColor index 3
-inconsistentColor index 3
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(P)$(R)SelectPixelDataFormat"
-font "arial-bold-r-12.0"
 endObjectProperties
 
 # (Rectangle)

--- a/ADPhantomApp/opi/edl/phantomBase.edl
+++ b/ADPhantomApp/opi/edl/phantomBase.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 221
-y 406
+x 179
+y 470
 w 390
 h 470
 font "arial-bold-r-12.0"
@@ -23,6 +23,44 @@ showGrid
 gridSize 5
 endScreenProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 205
+y 205
+w 92
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Pixel Data Type"
+}
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 306
+y 205
+w 74
+h 20
+fgColor index 14
+bgColor index 3
+inconsistentColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)SelectPixelDataFormat"
+font "arial-bold-r-12.0"
+endObjectProperties
+
 # (Rectangle)
 object activeRectangleClass
 beginObjectProperties
@@ -31,7 +69,7 @@ minor 0
 release 0
 x 0
 y 0
-w 390
+w 393
 h 470
 lineColor index 5
 fill
@@ -2268,43 +2306,5 @@ useDisplayBg
 value {
   "Acquisition Active"
 }
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 205
-y 205
-w 92
-h 20
-font "arial-bold-r-12.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "Pixel Data Type"
-}
-endObjectProperties
-
-# (Menu Button)
-object activeMenuButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 306
-y 205
-w 74
-h 20
-fgColor index 14
-bgColor index 3
-inconsistentColor index 3
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(P)$(R)SelectPixelDataFormat"
-font "arial-bold-r-12.0"
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomBase.edl
+++ b/ADPhantomApp/opi/edl/phantomBase.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 286
-y 233
+x 221
+y 406
 w 390
 h 470
 font "arial-bold-r-12.0"
@@ -20,7 +20,6 @@ ctlBgColor2 index 3
 topShadowColor index 1
 botShadowColor index 11
 showGrid
-snapToGrid
 gridSize 5
 endScreenProperties
 
@@ -132,46 +131,6 @@ minor 1
 release 1
 x 90
 y 120
-w 95
-h 20
-font "arial-bold-r-10.0"
-fontAlign "center"
-fgColor index 5
-bgColor index 3
-useDisplayBg
-value {
-  "N/A"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 285
-y 205
-w 95
-h 20
-font "arial-bold-r-10.0"
-fontAlign "center"
-fgColor index 5
-bgColor index 3
-useDisplayBg
-value {
-  "N/A"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 285
-y 230
 w 95
 h 20
 font "arial-bold-r-10.0"
@@ -527,7 +486,7 @@ minor 1
 release 1
 x 5
 y 5
-w 32
+w 2
 h 13
 font "arial-medium-r-12.0"
 fgColor index 14
@@ -642,7 +601,7 @@ minor 1
 release 1
 x 5
 y 105
-w 49
+w 2
 h 13
 font "arial-medium-r-12.0"
 fgColor index 14
@@ -952,7 +911,7 @@ minor 1
 release 1
 x 200
 y 105
-w 74
+w 2
 h 13
 font "arial-medium-r-12.0"
 fgColor index 14
@@ -1029,7 +988,7 @@ minor 1
 release 1
 x 200
 y 320
-w 48
+w 2
 h 13
 font "arial-medium-r-12.0"
 fgColor index 14
@@ -2309,5 +2268,43 @@ useDisplayBg
 value {
   "Acquisition Active"
 }
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 205
+y 205
+w 92
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Pixel Data Type"
+}
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 306
+y 205
+w 74
+h 20
+fgColor index 14
+bgColor index 3
+inconsistentColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)SelectPixelDataFormat"
+font "arial-bold-r-12.0"
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomCineDetails.edl
+++ b/ADPhantomApp/opi/edl/phantomCineDetails.edl
@@ -3,10 +3,10 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1595
-y 274
+x 1039
+y 470
 w 401
-h 321
+h 510
 font "arial-bold-r-12.0"
 fontAlign "center"
 ctlFont "arial-bold-r-12.0"
@@ -34,7 +34,7 @@ release 0
 x 0
 y 0
 w 400
-h 320
+h 350
 lineColor index 5
 fill
 fillColor index 5
@@ -49,7 +49,7 @@ release 0
 x 5
 y 15
 w 390
-h 300
+h 330
 lineColor index 14
 fill
 fillColor index 3
@@ -962,7 +962,7 @@ major 4
 minor 0
 release 0
 x 275
-y 280
+y 310
 w 85
 h 30
 
@@ -975,7 +975,7 @@ major 4
 minor 1
 release 1
 x 275
-y 280
+y 310
 w 85
 h 30
 font "arial-bold-r-12.0"
@@ -1004,7 +1004,7 @@ major 4
 minor 0
 release 0
 x 275
-y 280
+y 310
 w 85
 h 30
 
@@ -1017,7 +1017,7 @@ major 4
 minor 1
 release 0
 x 275
-y 280
+y 310
 w 85
 h 30
 fgColor index 20
@@ -1047,7 +1047,7 @@ major 4
 minor 0
 release 0
 x 180
-y 280
+y 310
 w 85
 h 30
 
@@ -1060,7 +1060,7 @@ major 4
 minor 1
 release 0
 x 180
-y 280
+y 310
 w 85
 h 30
 fgColor index 20
@@ -1082,5 +1082,43 @@ visPv "$(P)$(R)DownloadCount_RBV"
 visInvert
 visMin "0"
 visMax "1"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 20
+y 280
+w 92
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Pixel Token:"
+}
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 135
+y 280
+w 74
+h 20
+fgColor index 14
+bgColor index 3
+inconsistentColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)SelectPixelDataFormat"
+font "arial-bold-r-12.0"
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomDetails.edl
+++ b/ADPhantomApp/opi/edl/phantomDetails.edl
@@ -3,10 +3,10 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 721
-y 567
-w 720
-h 315
+x 229
+y 260
+w 1060
+h 314
 font "arial-bold-r-12.0"
 ctlFont "arial-bold-r-12.0"
 btnFont "arial-bold-r-12.0"
@@ -33,7 +33,7 @@ minor 0
 release 0
 x 0
 y 0
-w 720
+w 1090
 h 315
 lineColor index 5
 fill
@@ -48,7 +48,7 @@ minor 0
 release 0
 x 10
 y 250
-w 695
+w 685
 h 50
 lineColor index 14
 fill
@@ -117,14 +117,14 @@ minor 1
 release 1
 x 25
 y 35
-w 163
+w 167
 h 13
 font "arial-bold-r-12.0"
 fgColor index 14
 bgColor index 3
 useDisplayBg
 value {
-  "Sensor Temperauture (deg)"
+  "Sensor Temperature (deg C)"
 }
 autoSize
 endObjectProperties
@@ -156,14 +156,14 @@ minor 1
 release 1
 x 25
 y 60
-w 168
+w 172
 h 13
 font "arial-bold-r-12.0"
 fgColor index 14
 bgColor index 3
 useDisplayBg
 value {
-  "Camera Temperauture (deg)"
+  "Camera Temperature (deg C)"
 }
 autoSize
 endObjectProperties
@@ -357,7 +357,7 @@ beginObjectProperties
 major 4
 minor 1
 release 0
-x 595
+x 580
 y 265
 w 105
 h 20
@@ -439,7 +439,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 375
+x 365
 y 20
 w 330
 h 215
@@ -454,7 +454,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 375
+x 365
 y 10
 w 2
 h 13
@@ -651,7 +651,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 390
+x 380
 y 35
 w 52
 h 13
@@ -671,7 +671,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 500
+x 490
 y 30
 w 95
 h 20
@@ -689,7 +689,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 600
+x 590
 y 30
 w 85
 h 20
@@ -708,7 +708,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 390
+x 380
 y 160
 w 76
 h 13
@@ -728,7 +728,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 390
+x 380
 y 135
 w 106
 h 13
@@ -748,7 +748,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 390
+x 380
 y 110
 w 75
 h 13
@@ -768,7 +768,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 390
+x 380
 y 85
 w 102
 h 13
@@ -788,7 +788,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 390
+x 380
 y 60
 w 80
 h 13
@@ -808,7 +808,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 500
+x 490
 y 130
 w 95
 h 20
@@ -826,7 +826,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 500
+x 490
 y 80
 w 95
 h 20
@@ -844,7 +844,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 500
+x 490
 y 155
 w 95
 h 20
@@ -864,7 +864,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 500
+x 490
 y 105
 w 95
 h 20
@@ -884,7 +884,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 500
+x 490
 y 55
 w 95
 h 20
@@ -904,7 +904,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 600
+x 590
 y 155
 w 85
 h 20
@@ -923,7 +923,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 600
+x 590
 y 130
 w 85
 h 20
@@ -942,7 +942,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 600
+x 590
 y 105
 w 85
 h 20
@@ -961,7 +961,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 600
+x 590
 y 80
 w 85
 h 20
@@ -980,7 +980,7 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 600
+x 590
 y 55
 w 85
 h 20
@@ -991,5 +991,521 @@ bgColor index 10
 fill
 font "arial-bold-r-12.0"
 fontAlign "center"
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 720
+y 20
+w 330
+h 215
+lineColor index 14
+fill
+fillColor index 3
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 720
+y 10
+w 2
+h 13
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 5
+value {
+  "  Camera Details   "
+}
+autoSize
+border
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 735
+y 35
+w 74
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Auto Trigger"
+}
+autoSize
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 945
+y 30
+w 85
+h 20
+controlPv "$(P)$(R)AutoTriggerMode_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 735
+y 160
+w 78
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "AT Threshold"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 735
+y 135
+w 56
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "AT Y Size"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 735
+y 110
+w 56
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "AT X Size"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 735
+y 85
+w 71
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "AT Y Centre"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 735
+y 60
+w 71
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "AT X Centre"
+}
+autoSize
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 845
+y 130
+w 95
+h 20
+controlPv "$(P)$(R)AutoTriggerH"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 845
+y 80
+w 95
+h 20
+controlPv "$(P)$(R)AutoTriggerY"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 945
+y 155
+w 85
+h 20
+controlPv "$(P)$(R)AutoTriggerThresh_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 945
+y 130
+w 85
+h 20
+controlPv "$(P)$(R)AutoTriggerH_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 945
+y 105
+w 85
+h 20
+controlPv "$(P)$(R)AutoTriggerW_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 945
+y 80
+w 85
+h 20
+controlPv "$(P)$(R)AutoTriggerY_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 945
+y 55
+w 85
+h 20
+controlPv "$(P)$(R)AutoTriggerX_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 845
+y 30
+w 95
+h 20
+fgColor index 25
+bgColor index 3
+inconsistentColor index 0
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)AutoTriggerMode"
+indicatorPv "$(P)$(R)AutoTriggerMode_RBV"
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 845
+y 55
+w 95
+h 20
+controlPv "$(P)$(R)AutoTriggerX"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 845
+y 105
+w 95
+h 20
+controlPv "$(P)$(R)AutoTriggerW"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 845
+y 155
+w 95
+h 20
+controlPv "$(P)$(R)AutoTriggerThresh"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 735
+y 185
+w 72
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "AT Area (%)"
+}
+autoSize
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 845
+y 180
+w 95
+h 20
+controlPv "$(P)$(R)AutoTriggerArea"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 945
+y 180
+w 85
+h 20
+controlPv "$(P)$(R)AutoTriggerArea_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 735
+y 210
+w 65
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "AT Interval"
+}
+autoSize
+endObjectProperties
+
+# (Textentry)
+object TextentryClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 845
+y 205
+w 95
+h 20
+controlPv "$(P)$(R)AutoTriggerInterval"
+fgColor index 25
+fgAlarm
+bgColor index 3
+fill
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 945
+y 205
+w 85
+h 20
+controlPv "$(P)$(R)AutoTriggerInterval_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Related Display)
+object relatedDisplayClass
+beginObjectProperties
+major 4
+minor 4
+release 0
+x 975
+y 265
+w 70
+h 25
+fgColor index 14
+bgColor index 3
+topShadowColor index 1
+botShadowColor index 11
+font "arial-bold-r-12.0"
+buttonLabel "Cines"
+numPvs 4
+numDsps 1
+displayFileName {
+  0 "phantomCine"
+}
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomDownload.edl
+++ b/ADPhantomApp/opi/edl/phantomDownload.edl
@@ -3,10 +3,10 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 217
-y 443
+x 681
+y 125
 w 401
-h 250
+h 280
 font "arial-bold-r-12.0"
 fontAlign "center"
 ctlFont "arial-bold-r-12.0"
@@ -21,7 +21,6 @@ ctlBgColor2 index 3
 topShadowColor index 1
 botShadowColor index 11
 showGrid
-snapToGrid
 gridSize 5
 endScreenProperties
 
@@ -31,10 +30,10 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 0
+x -2
 y 0
 w 400
-h 250
+h 320
 lineColor index 5
 fill
 fillColor index 5
@@ -47,9 +46,9 @@ major 4
 minor 0
 release 0
 x 5
-y 15
+y 9
 w 390
-h 230
+h 255
 lineColor index 14
 fill
 fillColor index 3
@@ -175,8 +174,8 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 145
-y 200
+x 142
+y 228
 w 85
 h 20
 controlPv "$(P)$(R)DownloadCount_RBV"
@@ -194,8 +193,8 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 20
-y 205
+x 17
+y 233
 w 112
 h 13
 font "arial-bold-r-12.0"
@@ -472,8 +471,8 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 20
-y 140
+x 17
+y 168
 w 108
 h 13
 font "arial-bold-r-12.0"
@@ -492,8 +491,8 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 145
-y 135
+x 142
+y 163
 w 110
 h 25
 fgColor index 14
@@ -556,8 +555,8 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 20
-y 170
+x 17
+y 198
 w 106
 h 13
 font "arial-bold-r-12.0"
@@ -576,8 +575,8 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 145
-y 165
+x 142
+y 193
 w 110
 h 25
 fgColor index 14
@@ -588,5 +587,43 @@ botShadowColor index 11
 controlPv "$(P)$(R)MarkCineSaved"
 indicatorPv "$(P)$(R)MarkCineSaved_RBV"
 font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 142
+y 133
+w 110
+h 25
+fgColor index 14
+bgColor index 3
+inconsistentColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)SelectPixelDataFormat"
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 18
+y 136
+w 92
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Pixel Token:"
+}
 endObjectProperties
 

--- a/ADPhantomApp/opi/edl/phantomTop.edl
+++ b/ADPhantomApp/opi/edl/phantomTop.edl
@@ -4,7 +4,7 @@ major 4
 minor 0
 release 1
 x 1597
-y 134
+y 177
 w 400
 h 830
 font "arial-bold-r-12.0"
@@ -46,9 +46,9 @@ major 4
 minor 0
 release 0
 x 5
-y 485
+y 475
 w 175
-h 35
+h 45
 lineColor index 14
 fill
 fillColor index 3
@@ -105,9 +105,9 @@ major 4
 minor 0
 release 0
 x 185
-y 485
+y 475
 w 200
-h 35
+h 45
 lineColor index 14
 fill
 fillColor index 3
@@ -904,7 +904,10 @@ minor 1
 release 1
 x 20
 y 740
-w 69
+w 126
+x 10
+y 480
+w 126
 h 13
 font "arial-bold-r-12.0"
 fgColor index 14
@@ -912,6 +915,7 @@ bgColor index 3
 useDisplayBg
 value {
   "Auto-restart"
+  "Toggle Preview Mode"
 }
 autoSize
 endObjectProperties

--- a/ADPhantomApp/opi/edl/phantomTop.edl
+++ b/ADPhantomApp/opi/edl/phantomTop.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1597
-y 177
+x 1100
+y 223
 w 400
 h 830
 font "arial-bold-r-12.0"
@@ -20,7 +20,6 @@ ctlBgColor2 index 3
 topShadowColor index 1
 botShadowColor index 11
 showGrid
-snapToGrid
 gridSize 5
 endScreenProperties
 
@@ -902,9 +901,6 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 20
-y 740
-w 126
 x 10
 y 480
 w 126
@@ -914,8 +910,27 @@ fgColor index 14
 bgColor index 3
 useDisplayBg
 value {
-  "Auto-restart"
   "Toggle Preview Mode"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 20
+y 739
+w 69
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Auto-restart"
 }
 autoSize
 endObjectProperties

--- a/ADPhantomApp/opi/edl/phantomTop.edl
+++ b/ADPhantomApp/opi/edl/phantomTop.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 1509
-y 437
+x 1251
+y 177
 w 400
 h 830
 font "arial-bold-r-12.0"
@@ -46,9 +46,9 @@ major 4
 minor 0
 release 0
 x 5
-y 485
+y 475
 w 175
-h 35
+h 45
 lineColor index 14
 fill
 fillColor index 3
@@ -105,9 +105,9 @@ major 4
 minor 0
 release 0
 x 185
-y 485
+y 475
 w 200
-h 35
+h 45
 lineColor index 14
 fill
 fillColor index 3
@@ -932,5 +932,25 @@ fgAlarm
 bgColor index 3
 fill
 font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 480
+w 126
+h 13
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Toggle Preview Mode"
+}
+autoSize
 endObjectProperties
 

--- a/ADPhantomApp/src/ADPhantom.cpp
+++ b/ADPhantomApp/src/ADPhantom.cpp
@@ -2262,10 +2262,10 @@ asynStatus ADPhantom::writeInt32(asynUser *pasynUser, epicsInt32 value)
       else if (value==5){
         bitDepth_ = 12;
         phantomToken_ = "P12L";
-        printf("P12L selected!");
       }
       else{
         printf("Invalid Data Format selected!\n");
+        status = asynError;
       }
   }
 

--- a/ADPhantomApp/src/ADPhantom.cpp
+++ b/ADPhantomApp/src/ADPhantom.cpp
@@ -1609,7 +1609,7 @@ void ADPhantom::phantomDownloadTask()
         setStringParam(ADStatusMessage, "Ready");
       }
       else{
-        setStringParam(ADStatus, ADStatusError);
+        setIntegerParam(ADStatus, ADStatusError);
       }
    }  
   }
@@ -3425,7 +3425,8 @@ asynStatus ADPhantom::readoutDataStream(int start_cine, int end_cine, int start_
 
     // Flush the data connection
     pasynOctetSyncIO->flush(dataChannel_);
-    sprintf(command, "img {cine:%d, start:%d, cnt:%d, fmt:%s}", cine, start, frames, phantomToken_.c_str());  status = sendSimpleCommand(command, &response);
+    sprintf(command, "img {cine:%d, start:%d, cnt:%d, fmt:%s}", cine, first_frame, frames, phantomToken_.c_str());  
+    status = sendSimpleCommand(command, &response);
     debug(functionName, "Command", command);
     debug(functionName, "Response", response);
 

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -159,6 +159,8 @@
 #define PHANTOM_SetPartitionString             "PHANTOM_SET_PARTITION"
 #define PHANTOM_GetCineCountString             "PHANTOM_GET_CINE_COUNT"
 
+#define PHANTOM_DataFormatString               "PHANTOM_DATA_FORMAT"   // Integer corresponding to format token (8,8R,P16,P16R,P10,P12L)
+
 #define PHANTOM_CFStateString                  "PHANTOM_CF_STATE"
 #define PHANTOM_CFActionString                 "PHANTOM_CF_ACTION"
 #define PHANTOM_CFSizeString                   "PHANTOM_CF_SIZE"
@@ -747,9 +749,10 @@ class ADPhantom: public ADDriver
     int PHANTOM_CfFileName_[PHANTOM_NUMBER_OF_FLASH_FILES];
     int PHANTOM_CfFileSize_[PHANTOM_NUMBER_OF_FLASH_FILES];
     int PHANTOM_CfFileDate_[PHANTOM_NUMBER_OF_FLASH_FILES];
+    int PHANTOM_DataFormat_;
     int PHANTOMConnected_;
-    int PHANTOM_SyncClock;
-    #define LAST_PHANTOM_PARAM PHANTOMConnected_
+    int PHANTOM_SyncClock_;
+    #define LAST_PHANTOM_PARAM PHANTOM_SyncClock_
 
   private:
     static const int PHANTOM_LinLUT[1024];
@@ -784,6 +787,8 @@ class ADPhantom: public ADDriver
     int                                flashTrigUsecs_;
     int                                previewWidth_;
     int                                previewHeight_;
+    int                                bitDepth_;
+    std::string                        phantomToken_;
     std::map<std::string, int>         debugMap_;
     epicsEventId                       startEventId_;
     epicsEventId                       stopEventId_;

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -159,7 +159,7 @@
 #define PHANTOM_SetPartitionString             "PHANTOM_SET_PARTITION"
 #define PHANTOM_GetCineCountString             "PHANTOM_GET_CINE_COUNT"
 
-#define PHANTOM_DataFormatString               "PHANTOM_DATA_FORMAT"   // Integer corresponding to format token (8,8R,P16,P16R,P10,P12L)
+#define PHANTOM_DataFormatString               "PHANTOM_DataFormat"   // Integer corresponding to format token (8,8R,P16,P16R,P10,P12L)
 
 #define PHANTOM_CFStateString                  "PHANTOM_CF_STATE"
 #define PHANTOM_CFActionString                 "PHANTOM_CF_ACTION"
@@ -605,7 +605,9 @@ class ADPhantom: public ADDriver
     asynStatus downloadFlashFile();
     asynStatus downloadFlashHeader(const std::string& filename);
     asynStatus downloadFlashImages(const std::string& filename, int start, int end);
-    asynStatus convert10BitPacketTo12Bit(void *input, void *output);
+    asynStatus convert12BitPacketTo16Bit(void *input, void *output);
+    asynStatus convert10BitPacketTo16Bit(void *input, void *output);
+    asynStatus convert8BitPacketTo16Bit(void *input, void *output, int nBytes);
     asynStatus readoutTimestamps(int cine, int start, int end);
     asynStatus readoutDataStream(int cine, int start, int end);
     asynStatus readFrame(int bytes);

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -171,6 +171,8 @@
 #define PHANTOM_SetPartitionString             "PHANTOM_SET_PARTITION"
 #define PHANTOM_GetCineCountString             "PHANTOM_GET_CINE_COUNT"
 
+#define PHANTOM_DataFormatString               "PHANTOM_DataFormat"   // Integer corresponding to format token (8,8R,P16,P16R,P10,P12L)
+
 #define PHANTOM_CFStateString                  "PHANTOM_CF_STATE"
 #define PHANTOM_CFActionString                 "PHANTOM_CF_ACTION"
 #define PHANTOM_CFSizeString                   "PHANTOM_CF_SIZE"
@@ -616,9 +618,11 @@ class ADPhantom: public ADDriver
     asynStatus downloadFlashFile();
     asynStatus downloadFlashHeader(const std::string& filename);
     asynStatus downloadFlashImages(const std::string& filename, int start, int end);
-    asynStatus convert10BitPacketTo12Bit(void *input, void *output);
     asynStatus readoutTimestamps(int start_cine, int end_cine, int start_frame, int end_frame, bool uni_frame_lim);
     asynStatus readoutDataStream(int start_cine, int end_cine, int start_frame, int end_frame, bool uni_frame_lim);
+    asynStatus convert12BitPacketTo16Bit(void *input, void *output);
+    asynStatus convert10BitPacketTo16Bit(void *input, void *output);
+    asynStatus convert8BitPacketTo16Bit(void *input, void *output, int nBytes);
     asynStatus readFrame(int bytes);
     asynStatus updatePreviewCine();
     asynStatus updateCine(int cine);
@@ -667,6 +671,9 @@ class ADPhantom: public ADDriver
     asynStatus debug(const std::string& method, const std::string& msg, double value);
     asynStatus debug(const std::string& method, const std::string& msg, const std::string& value);
     asynStatus debug(const std::string& method, const std::string& msg, std::map<std::string, std::string> value);
+
+    //Temp
+    struct timespec start_;
 
   protected:
     int PHANTOMConnect_;
@@ -766,9 +773,10 @@ class ADPhantom: public ADDriver
     int PHANTOM_CfFileName_[PHANTOM_NUMBER_OF_FLASH_FILES];
     int PHANTOM_CfFileSize_[PHANTOM_NUMBER_OF_FLASH_FILES];
     int PHANTOM_CfFileDate_[PHANTOM_NUMBER_OF_FLASH_FILES];
+    int PHANTOM_DataFormat_;
     int PHANTOMConnected_;
-    int PHANTOM_SyncClock;
-    #define LAST_PHANTOM_PARAM PHANTOMConnected_
+    int PHANTOM_SyncClock_;
+    #define LAST_PHANTOM_PARAM PHANTOM_SyncClock_
 
   private:
     static const int PHANTOM_LinLUT[1024];
@@ -804,6 +812,8 @@ class ADPhantom: public ADDriver
     int                                flashTrigUsecs_;
     int                                previewWidth_;
     int                                previewHeight_;
+    int                                bitDepth_;
+    std::string                        phantomToken_;
     std::map<std::string, int>         debugMap_;
     epicsEventId                       startEventId_;
     epicsEventId                       stopEventId_;

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -655,6 +655,9 @@ class ADPhantom: public ADDriver
     asynStatus debug(const std::string& method, const std::string& msg, const std::string& value);
     asynStatus debug(const std::string& method, const std::string& msg, std::map<std::string, std::string> value);
 
+    //Temp
+    struct timespec start_;
+
   protected:
     int PHANTOMConnect_;
     #define FIRST_PHANTOM_PARAM PHANTOMConnect_

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -31,3 +31,14 @@ CROSS_COMPILER_TARGET_ARCHS =
 # You must rebuild in the iocBoot directory for this to
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+#Switch these on for debugging
+#HOST_OPT=NO
+#CROSS_OPT=NO
+#USR_CXXFLAGS=-g
+#USR_LDFLAGS=-g
+#USR_CPPFLAGS_Linux += -g
+#USR_CFLAGS_Linux += -g
+#USR_LDFLAGS_Linux += -g
+#STATIC_BUILD=YES
+


### PR DESCRIPTION
This is @ptsOSL 's work but I worked to fix the git history. This pull request replaces https://github.com/dls-controls/ADPhantom/pull/11

Phil has implemented the ability to select any of the pixel tokens for the camera data. This has been tested for both the preview mode and the downloading of cines. A new dropdown box has been added to select the pixel token from the cine detail page and the download page.

Phil has also added a label to make it clear which buttons control the preview mode.