### PR TITLE
Parallel data conversion

### DIFF
--- a/ADPhantomApp/Db/phantomCamera.template
+++ b/ADPhantomApp/Db/phantomCamera.template
@@ -1188,6 +1188,16 @@ record(mbbo, "$(P)$(R)SelectPixelDataFormat")
   field(FVVL, "5")
 }
 
+###
+### Driver frame read speed
+###
+record(longin, "$(P)$(R)FrameReadSpeed_RBV")
+{
+  field(DESC, "Frames processed by driver per second")
+  field(DTYP, "asynInt32")
+  field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PHANTOM_FRAMES_PER_SECOND")
+  field(SCAN, "I/O Intr")
+}
 
 include "phantomFlash.template"
 

--- a/ADPhantomApp/opi/edl/phantomBase.edl
+++ b/ADPhantomApp/opi/edl/phantomBase.edl
@@ -3,8 +3,8 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 429
-y 343
+x 847
+y 268
 w 390
 h 470
 font "arial-bold-r-12.0"
@@ -2287,5 +2287,64 @@ useDisplayBg
 value {
   "Acquisition Active"
 }
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 205
+y 206
+w 122
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Frames Per Second"
+}
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 332
+y 207
+w 47
+h 20
+
+beginGroup
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 332
+y 207
+w 47
+h 20
+controlPv "$(P)$(R)FrameReadSpeed_RBV"
+displayMode "decimal"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+endGroup
+
+visPv "$(P)$(R)FrameReadSpeed_RBV.DISA"
+visMin "0"
+visMax "1"
 endObjectProperties
 

--- a/ADPhantomApp/src/ADPhantom.cpp
+++ b/ADPhantomApp/src/ADPhantom.cpp
@@ -1623,7 +1623,6 @@ void ADPhantom::phantomDownloadTask()
             rangeValid=false;
             setStringParam(ADStatusMessage, "end_frame cannot be less than start_frame within a cine");
           }
-          downloadingFlag_ = 0;
         }
 
         if(rangeValid){
@@ -1647,7 +1646,7 @@ void ADPhantom::phantomDownloadTask()
         setIntegerParam(ADStatus, status);
       }
     }  
-   setIntegerParam(PHANTOM_Download_, 1);
+   downloadingFlag_ = 0;
   }
 }
 

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -824,6 +824,7 @@ class ADPhantom: public ADDriver
     int                                bitDepth_;
     int                                conversionBitDepth_;
     int                                conversionBytes_;
+    int                                downloadingFlag_;
     std::string                        phantomToken_;
     std::map<std::string, int>         debugMap_;
     epicsEventId                       startEventId_;

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <algorithm>
 #include <ctime>
+#include <pthread.h>
 
 // EPICS includes
 #include <epicsThread.h>
@@ -621,6 +622,8 @@ class ADPhantom: public ADDriver
     asynStatus downloadFlashImages(const std::string& filename, int start, int end);
     asynStatus readoutTimestamps(int start_cine, int end_cine, int start_frame, int end_frame, bool uni_frame_lim);
     asynStatus readoutDataStream(int start_cine, int end_cine, int start_frame, int end_frame, bool uni_frame_lim);
+    asynStatus convertPixelData(int nBytes);
+    asynStatus conversionMiddle();
     asynStatus convert12BitPacketTo16Bit(void *input, void *output);
     asynStatus convert10BitPacketTo16Bit(void *input, void *output);
     asynStatus convert8BitPacketTo16Bit(void *input, void *output, int nBytes);
@@ -805,6 +808,7 @@ class ADPhantom: public ADDriver
     char                               data_[2048000];
     char                               imgData_[2048000];
     char                               flashData_[2048000];
+    char                               downloadData_[102400000]; // 50, 2MB images
     std::vector<short_time_stamp32>    timestampData_;
     std::vector<tagTIME64>             flashTsData_;
     std::vector<uint32_t>              flashExpData_;
@@ -834,6 +838,7 @@ class ADPhantom: public ADDriver
     CINEFILEHEADER                     cineHeader_;
     BITMAPINFOHEADER                   cineBitmapHeader_;
     SETUP                              cineSetupHeader_;
+    epicsEventId                       conversionEvt_[10];
 
 };
 

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -145,6 +145,7 @@
 #define PHANTOM_PostTrigCountString            "PHANTOM_POST_TRIG_COUNT"
 #define PHANTOM_TotalFrameCountString          "PHANTOM_TOTAL_FRAME_COUNT"
 #define PHANTOM_MaxFrameCountString            "PHANTOM_MAX_FRAME_COUNT"
+#define PHANTOM_FramesPerSecondString          "PHANTOM_FRAMES_PER_SECOND"
 
 #define PHANTOM_CineNameString                 "PHANTOM_CINE_NAME"
 #define PHANTOM_SelectedCineString             "PHANTOM_CINE_SELECTED"
@@ -672,8 +673,8 @@ class ADPhantom: public ADDriver
     asynStatus debug(const std::string& method, const std::string& msg, const std::string& value);
     asynStatus debug(const std::string& method, const std::string& msg, std::map<std::string, std::string> value);
 
-    //Temp
-    struct timespec start_;
+    struct timespec frameStart_;
+    struct timespec readStart_;
 
   protected:
     int PHANTOMConnect_;
@@ -775,6 +776,7 @@ class ADPhantom: public ADDriver
     int PHANTOM_CfFileDate_[PHANTOM_NUMBER_OF_FLASH_FILES];
     int PHANTOM_DataFormat_;
     int PHANTOMConnected_;
+    int PHANTOM_FramesPerSecond_;
     int PHANTOM_SyncClock_;
     #define LAST_PHANTOM_PARAM PHANTOM_SyncClock_
 

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -47,6 +47,9 @@
 #define PHANTOM_OK_STRING    "Ok!"
 #define PHANTOM_ERROR_STRING "ERR:"
 
+// Number of Conversion Threads
+#define PHANTOM_CONV_THREADS 10
+
 // PHANTOM Run Modes
 #define PHANTOM_RUN_FAT  0
 #define PHANTOM_RUN_SFAT 1
@@ -597,6 +600,7 @@ class ADPhantom: public ADDriver
     void phantomPreviewTask();
     void phantomFlashTask();
     void phantomDownloadTask();
+    void phantomConversionTask();
     asynStatus makeConnection();
     asynStatus connect();
     asynStatus disconnect();
@@ -623,7 +627,6 @@ class ADPhantom: public ADDriver
     asynStatus readoutTimestamps(int start_cine, int end_cine, int start_frame, int end_frame, bool uni_frame_lim);
     asynStatus readoutDataStream(int start_cine, int end_cine, int start_frame, int end_frame, bool uni_frame_lim);
     asynStatus convertPixelData(int nBytes);
-    asynStatus conversionMiddle();
     asynStatus convert12BitPacketTo16Bit(void *input, void *output);
     asynStatus convert10BitPacketTo16Bit(void *input, void *output);
     asynStatus convert8BitPacketTo16Bit(void *input, void *output, int nBytes);
@@ -819,6 +822,8 @@ class ADPhantom: public ADDriver
     int                                previewWidth_;
     int                                previewHeight_;
     int                                bitDepth_;
+    int                                conversionBitDepth_;
+    int                                conversionBytes_;
     std::string                        phantomToken_;
     std::map<std::string, int>         debugMap_;
     epicsEventId                       startEventId_;
@@ -827,18 +832,19 @@ class ADPhantom: public ADDriver
     epicsEventId                       startPreviewEventId_;
     epicsEventId                       stopPreviewEventId_;
     epicsEventId                       flashEventId_;
-    std::vector<PhantomMeta *>            metaArray_;
+    epicsEventId                       convStartEvt_[PHANTOM_CONV_THREADS];
+    epicsEventId                       convFinishEvt_[PHANTOM_CONV_THREADS];
+    std::vector<PhantomMeta *>         metaArray_;
     std::vector<std::string>           lensModes_;
     std::vector<std::string>           scanRanges_;
     std::vector<std::string>           runModes_;
-    std::map<std::string, phantomVal> paramMap_;
+    std::map<std::string, phantomVal>  paramMap_;
     std::map<int, std::string>         paramIndexes_;
     std::vector<std::vector<std::string> > fileInfoSet_;
     bool                               firstConnect_;
     CINEFILEHEADER                     cineHeader_;
     BITMAPINFOHEADER                   cineBitmapHeader_;
     SETUP                              cineSetupHeader_;
-    epicsEventId                       conversionEvt_[10];
 
 };
 

--- a/ADPhantomApp/src/ADPhantom.h
+++ b/ADPhantomApp/src/ADPhantom.h
@@ -627,9 +627,9 @@ class ADPhantom: public ADDriver
     asynStatus readoutTimestamps(int start_cine, int end_cine, int start_frame, int end_frame, bool uni_frame_lim);
     asynStatus readoutDataStream(int start_cine, int end_cine, int start_frame, int end_frame, bool uni_frame_lim);
     asynStatus convertPixelData(int nBytes);
-    asynStatus convert12BitPacketTo16Bit(void *input, void *output);
-    asynStatus convert10BitPacketTo16Bit(void *input, void *output);
-    asynStatus convert8BitPacketTo16Bit(void *input, void *output, int nBytes);
+    asynStatus convert12BitPacketTo16Bit(unsigned char *input, unsigned char *output);
+    asynStatus convert10BitPacketTo16Bit(unsigned char *input, unsigned char *output);
+    asynStatus convert8BitPacketTo16Bit(unsigned char *input, unsigned char *output, int nBytes);
     asynStatus readFrame(int bytes);
     asynStatus updatePreviewCine();
     asynStatus updateCine(int cine);

--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -27,4 +27,3 @@ ifdef T_A
  -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
  -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
 endif
-

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -32,15 +32,17 @@ CROSS_COMPILER_TARGET_ARCHS =
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
+USR_CPPFLAGS_Linux += -std=c++11
+
 #Switch these on for debugging
-#HOST_OPT=NO
-#CROSS_OPT=NO
-#USR_CXXFLAGS=-g
-#USR_LDFLAGS=-g
-#USR_CPPFLAGS_Linux += -g
-#USR_CFLAGS_Linux += -g
-#USR_LDFLAGS_Linux += -g
-#STATIC_BUILD=YES
+HOST_OPT=NO
+CROSS_OPT=NO
+USR_CXXFLAGS=-g
+USR_LDFLAGS=-g
+USR_CPPFLAGS_Linux += -g
+USR_CFLAGS_Linux += -g
+USR_LDFLAGS_Linux += -g
+STATIC_BUILD=YES
 
 #Switch these on for gprof profiling
 USR_CXXFLAGS=-pg

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -42,3 +42,20 @@ CROSS_COMPILER_TARGET_ARCHS =
 #USR_LDFLAGS_Linux += -g
 #STATIC_BUILD=YES
 
+#Switch these on for gprof profiling
+USR_CXXFLAGS=-pg
+USR_LDFLAGS=-pg
+USR_CPPFLAGS_Linux += -pg
+USR_CPPFLAGS_Linux += -Og
+USR_CFLAGS_Linux += -pg
+USR_LDFLAGS_Linux += -pg
+
+
+# Get settings from AREA_DETECTOR, so we only have to configure once for all detectors if we want to
+#-include $(AREA_DETECTOR)/configure/CONFIG_SITE
+#-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH)
+#-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#ifdef T_A
+#  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.Common.$(T_A)
+#  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+#endif

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -33,25 +33,27 @@ CROSS_COMPILER_TARGET_ARCHS =
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
 USR_CPPFLAGS_Linux += -std=c++11
+USR_CPPFLAGS_Linux += -O3
 
 #Switch these on for debugging
 HOST_OPT=NO
 CROSS_OPT=NO
-USR_CXXFLAGS=-g
-USR_LDFLAGS=-g
-USR_CPPFLAGS_Linux += -g
-USR_CFLAGS_Linux += -g
-USR_LDFLAGS_Linux += -g
+#USR_CXXFLAGS=-g
+#USR_LDFLAGS=-g
+#USR_CPPFLAGS_Linux += -g
+#USR_CFLAGS_Linux += -g
+#USR_LDFLAGS_Linux += -g
 STATIC_BUILD=YES
 
 #Switch these on for gprof profiling
-USR_CXXFLAGS=-pg
-USR_LDFLAGS=-pg
-USR_CPPFLAGS_Linux += -pg
-USR_CPPFLAGS_Linux += -Og
-USR_CFLAGS_Linux += -pg
-USR_LDFLAGS_Linux += -pg
+#USR_CXXFLAGS=-pg
+#USR_LDFLAGS=-pg
+#USR_CPPFLAGS_Linux += -pg
+#USR_CPPFLAGS_Linux += -Og
+#USR_CFLAGS_Linux += -pg
+#USR_LDFLAGS_Linux += -pg
 
+USR_CXXFLAHS=-O3
 
 # Get settings from AREA_DETECTOR, so we only have to configure once for all detectors if we want to
 #-include $(AREA_DETECTOR)/configure/CONFIG_SITE


### PR DESCRIPTION
- Created 10 threads to convert data in parallel
- Improved efficiency of conversion functions
- Neatened up calling of conversion function, now done through epics events
- Fixed compiler warnings
- Neatened up optional timing debug messages
- Added check to stop changing of pixel type during download
- Add 5 second sleep to read/writing of camera metadata during a download as it causes 300ms stutters
- Added main fps counter for ADPhantom
- Slightly improved usage of asynStatus in some places, but there is still a lot of redundant storing of statuses which are never properly checked